### PR TITLE
PARACORD_TLS_ENABLED is now respected and assigned into the config

### DIFF
--- a/crates/paracord-server/src/config.rs
+++ b/crates/paracord-server/src/config.rs
@@ -951,6 +951,11 @@ impl Config {
                 config.network.windows_firewall_auto_allow = parsed;
             }
         }
+        if let Ok(value) = std::env::var("PARACORD_TLS_ENABLED") {
+            if let Ok(parsed) = value.parse::<bool>() {
+                config.tls.enabled = parsed;
+            }
+        }
         if let Ok(value) = std::env::var("PARACORD_TLS_ACME_ENABLED") {
             if let Ok(parsed) = value.parse::<bool>() {
                 config.tls.acme.enabled = parsed;


### PR DESCRIPTION
As you commented in the docker-compose file the PARACORD_TLS_ENABLED should be used when its behind a reverse proxy. But i noticed it was never working ( i tried going to the docker compose setup but it tried to redirect to 8443. After fixing this it stayed to 8090.