### PR TITLE
feat: in-memory MemberIndex for zero-query presence dispatch

### DIFF
--- a/crates/paracord-api/src/routes/admin.rs
+++ b/crates/paracord-api/src/routes/admin.rs
@@ -444,6 +444,7 @@ pub async fn delete_guild(
 ) -> Result<StatusCode, ApiError> {
     paracord_core::admin::admin_delete_guild(&state.db, guild_id).await?;
 
+    state.member_index.remove_guild(guild_id);
     state.event_bus.dispatch(
         "GUILD_DELETE",
         json!({"id": guild_id.to_string()}),

--- a/crates/paracord-api/src/routes/bans.rs
+++ b/crates/paracord-api/src/routes/bans.rs
@@ -106,6 +106,7 @@ pub async fn ban_member(
         Some(guild_id),
     );
 
+    state.member_index.remove_member(guild_id, user_id);
     state.event_bus.dispatch(
         "GUILD_MEMBER_REMOVE",
         json!({

--- a/crates/paracord-api/src/routes/bots.rs
+++ b/crates/paracord-api/src/routes/bots.rs
@@ -368,6 +368,7 @@ pub async fn delete_bot_application(
     for install in installs {
         let _ =
             paracord_db::members::remove_member(&state.db, app.bot_user_id, install.guild_id).await;
+        state.member_index.remove_member(install.guild_id, app.bot_user_id);
         state.event_bus.dispatch(
             "GUILD_MEMBER_REMOVE",
             json!({
@@ -485,6 +486,7 @@ pub async fn remove_guild_bot(
         .map_err(|e| ApiError::Internal(anyhow::anyhow!(e.to_string())))?;
     let _ = paracord_db::members::remove_member(&state.db, app.bot_user_id, guild_id).await;
 
+    state.member_index.remove_member(guild_id, app.bot_user_id);
     state.event_bus.dispatch(
         "GUILD_MEMBER_REMOVE",
         json!({
@@ -567,6 +569,7 @@ pub async fn oauth2_authorize(
     .await
     .map_err(|e| ApiError::Internal(anyhow::anyhow!(e.to_string())))?;
     let _ = paracord_db::members::add_member(&state.db, app.bot_user_id, guild_id).await;
+    state.member_index.add_member(guild_id, app.bot_user_id);
 
     let user_row = paracord_db::users::get_user_by_id(&state.db, app.bot_user_id)
         .await

--- a/crates/paracord-api/src/routes/federation.rs
+++ b/crates/paracord-api/src/routes/federation.rs
@@ -1651,6 +1651,7 @@ async fn dispatch_federated_member_join(state: &AppState, payload: &FederationEv
         guild_id,
     )
     .await;
+    state.member_index.add_member(guild_id, local_user_id);
     state.event_bus.dispatch(
         "GUILD_MEMBER_ADD",
         json!({
@@ -1715,6 +1716,7 @@ async fn dispatch_federated_member_leave(state: &AppState, payload: &FederationE
         &identity.to_canonical(),
     )
     .await;
+    state.member_index.remove_member(guild_id, mapping.local_user_id);
     state.event_bus.dispatch(
         "GUILD_MEMBER_REMOVE",
         json!({
@@ -2135,6 +2137,7 @@ pub async fn join(
     .await
     .map_err(|e| ApiError::Internal(anyhow::anyhow!(e.to_string())))?;
 
+    state.member_index.add_member(guild_id, local_user_id);
     state.event_bus.dispatch(
         "GUILD_MEMBER_ADD",
         json!({
@@ -2205,6 +2208,7 @@ pub async fn leave(
             .await
             .map_err(|e| ApiError::Internal(anyhow::anyhow!(e.to_string())))?;
         removed = true;
+        state.member_index.remove_member(guild_id, mapping.local_user_id);
         state.event_bus.dispatch(
             "GUILD_MEMBER_REMOVE",
             json!({

--- a/crates/paracord-api/src/routes/guilds.rs
+++ b/crates/paracord-api/src/routes/guilds.rs
@@ -73,6 +73,7 @@ pub async fn create_guild(
         "created_at": guild.created_at.to_rfc3339(),
     });
 
+    state.member_index.add_member(guild_id, auth.user_id);
     state
         .event_bus
         .dispatch("GUILD_CREATE", guild_json.clone(), Some(guild_id));
@@ -195,6 +196,7 @@ pub async fn delete_guild(
 ) -> Result<StatusCode, ApiError> {
     paracord_core::guild::delete_guild(&state.db, guild_id, auth.user_id).await?;
 
+    state.member_index.remove_guild(guild_id);
     state.event_bus.dispatch(
         "GUILD_DELETE",
         json!({"id": guild_id.to_string()}),

--- a/crates/paracord-api/src/routes/invites.rs
+++ b/crates/paracord-api/src/routes/invites.rs
@@ -337,6 +337,7 @@ pub async fn accept_invite(
 
     // Only dispatch GUILD_MEMBER_ADD for genuinely new members
     if !already_member {
+        state.member_index.add_member(guild.id, auth.user_id);
         state.event_bus.dispatch(
             "GUILD_MEMBER_ADD",
             json!({"guild_id": guild.id.to_string(), "user_id": auth.user_id.to_string()}),

--- a/crates/paracord-api/src/routes/members.rs
+++ b/crates/paracord-api/src/routes/members.rs
@@ -265,6 +265,7 @@ pub async fn kick_member(
 ) -> Result<StatusCode, ApiError> {
     paracord_core::admin::kick_member(&state.db, guild_id, auth.user_id, user_id).await?;
 
+    state.member_index.remove_member(guild_id, user_id);
     state.event_bus.dispatch(
         "GUILD_MEMBER_REMOVE",
         json!({
@@ -316,6 +317,7 @@ pub async fn leave_guild(
         .await
         .map_err(|e| ApiError::Internal(anyhow::anyhow!(e.to_string())))?;
 
+    state.member_index.remove_member(guild_id, auth.user_id);
     state.event_bus.dispatch(
         "GUILD_MEMBER_REMOVE",
         json!({

--- a/crates/paracord-core/Cargo.toml
+++ b/crates/paracord-core/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 [dependencies]
 paracord-models = { workspace = true }
 paracord-db = { workspace = true }
+sqlx = { workspace = true }
 paracord-util = { workspace = true }
 paracord-media = { workspace = true }
 paracord-federation = { workspace = true }

--- a/crates/paracord-core/src/lib.rs
+++ b/crates/paracord-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod error;
 pub mod events;
 pub mod guild;
 pub mod identity;
+pub mod member_index;
 pub mod message;
 pub mod observability;
 pub mod permissions;
@@ -86,6 +87,8 @@ pub struct AppState {
     pub permission_cache: moka::future::Cache<PermissionCacheKey, Permissions>,
     /// Pre-built federation service (avoids re-parsing env vars on every request).
     pub federation_service: Option<FederationService>,
+    /// In-memory guild→members index for zero-query presence dispatch.
+    pub member_index: Arc<member_index::MemberIndex>,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/paracord-core/src/member_index.rs
+++ b/crates/paracord-core/src/member_index.rs
@@ -1,0 +1,66 @@
+use dashmap::DashMap;
+use paracord_db::{DbError, DbPool};
+use std::collections::HashSet;
+
+/// In-memory index: Guild -> Set<UserId>.
+/// Loaded from DB at server start and kept in sync via event-driven updates.
+/// Eliminates per-guild DB queries during presence dispatch.
+pub struct MemberIndex {
+    guilds: DashMap<i64, HashSet<i64>>,
+}
+
+impl MemberIndex {
+    pub async fn load_from_db(db: &DbPool) -> Result<Self, DbError> {
+        let index = MemberIndex {
+            guilds: DashMap::new(),
+        };
+
+        let rows: Vec<(i64, i64)> =
+            sqlx::query_as("SELECT guild_id, user_id FROM members")
+                .fetch_all(db)
+                .await?;
+
+        for (guild_id, user_id) in rows {
+            index
+                .guilds
+                .entry(guild_id)
+                .or_insert_with(HashSet::new)
+                .insert(user_id);
+        }
+
+        tracing::info!(guilds = index.guilds.len(), "member index loaded");
+        Ok(index)
+    }
+
+    /// All users who can see a given user (members of shared guilds), excluding the user itself.
+    pub fn get_presence_recipients(&self, user_id: i64, guild_ids: &[i64]) -> HashSet<i64> {
+        let mut recipients = HashSet::new();
+        for gid in guild_ids {
+            if let Some(members) = self.guilds.get(gid) {
+                recipients.extend(members.iter());
+            }
+        }
+        recipients.remove(&user_id);
+        recipients
+    }
+
+    /// Track a new member (called on GUILD_MEMBER_ADD).
+    pub fn add_member(&self, guild_id: i64, user_id: i64) {
+        self.guilds
+            .entry(guild_id)
+            .or_insert_with(HashSet::new)
+            .insert(user_id);
+    }
+
+    /// Remove a member (called on GUILD_MEMBER_REMOVE).
+    pub fn remove_member(&self, guild_id: i64, user_id: i64) {
+        if let Some(mut members) = self.guilds.get_mut(&guild_id) {
+            members.remove(&user_id);
+        }
+    }
+
+    /// Drop an entire guild (called on GUILD_DELETE).
+    pub fn remove_guild(&self, guild_id: i64) {
+        self.guilds.remove(&guild_id);
+    }
+}

--- a/crates/paracord-server/src/main.rs
+++ b/crates/paracord-server/src/main.rs
@@ -476,6 +476,10 @@ async fn main() -> Result<()> {
         None
     };
 
+    let member_index = paracord_core::member_index::MemberIndex::load_from_db(&db)
+        .await
+        .context("failed to load member index")?;
+
     let state = paracord_core::AppState {
         db,
         event_bus: paracord_core::events::EventBus::default(),
@@ -519,6 +523,7 @@ async fn main() -> Result<()> {
         user_presences: Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
         permission_cache: paracord_core::build_permission_cache(),
         federation_service,
+        member_index: Arc::new(member_index),
     };
 
     paracord_api::install_http_rate_limiter();

--- a/crates/paracord-ws/src/handler.rs
+++ b/crates/paracord-ws/src/handler.rs
@@ -4,7 +4,7 @@ use paracord_core::{observability, AppState};
 use paracord_models::gateway::*;
 use paracord_models::permissions::Permissions;
 use serde_json::{json, Value};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 use std::sync::{Arc, OnceLock};
 use tokio::sync::Semaphore;
@@ -450,17 +450,11 @@ async fn collect_presence_recipient_ids(
     user_id: i64,
     guild_ids: &[i64],
 ) -> Vec<i64> {
-    let mut recipients: HashSet<i64> = HashSet::new();
+    // In-memory lookup: zero DB queries for guild members
+    let mut recipients = state.member_index.get_presence_recipients(user_id, guild_ids);
     recipients.insert(user_id);
 
-    for &guild_id in guild_ids {
-        if let Ok(member_ids) =
-            paracord_db::members::get_guild_member_user_ids(&state.db, guild_id).await
-        {
-            recipients.extend(member_ids);
-        }
-    }
-
+    // Friends still need a DB query (not tracked in the member index)
     if let Ok(friend_ids) =
         paracord_db::relationships::get_friend_user_ids(&state.db, user_id).await
     {


### PR DESCRIPTION
## Summary
- Add `MemberIndex` (DashMap-backed in-memory guild→members index) to eliminate per-guild DB queries during presence dispatch
- Bulk-load all memberships from DB at server startup; keep index in sync via `add_member`/`remove_member`/`remove_guild` calls at every GUILD_MEMBER_ADD/REMOVE and GUILD_DELETE dispatch site
- Replace N+1 DB queries in `collect_presence_recipient_ids` with a single in-memory lookup (friend-list DB query retained)

## Test plan
- [ ] Server starts and logs `member index loaded: X guilds`
- [ ] User changes status → all guild members receive PRESENCE_UPDATE
- [ ] User kicked/banned/leaves guild → stops receiving presence events from that guild
- [ ] New member joins via invite → immediately receives presence events
- [ ] Guild deleted → no stale presence dispatch to former members
- [ ] Bot added/removed from guild → index stays consistent