### PR TITLE
fix(federation): prevent SSRF via federated file download proxy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ anyhow = "1"
 
 # Networking
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+url = "2"
 tokio-tungstenite = "0.28"
 
 # Process management

--- a/crates/paracord-federation/Cargo.toml
+++ b/crates/paracord-federation/Cargo.toml
@@ -19,3 +19,4 @@ reqwest = { workspace = true }
 chrono = { workspace = true }
 rand = { workspace = true }
 sha2 = { workspace = true }
+url = { workspace = true }

--- a/crates/paracord-federation/src/client.rs
+++ b/crates/paracord-federation/src/client.rs
@@ -4,11 +4,13 @@ use crate::transport;
 use crate::{FederationError, FederationEventEnvelope, FederationServerKey};
 use ed25519_dalek::SigningKey;
 use reqwest::Client;
+use std::net::IpAddr;
 use std::time::Duration;
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(15);
 const MAX_RETRIES: u32 = 3;
 const RETRY_BASE_DELAY: Duration = Duration::from_millis(500);
+const MAX_REDIRECTS: usize = 3;
 
 #[derive(Debug, Clone)]
 struct TransportSigner {
@@ -45,6 +47,7 @@ impl FederationClient {
         let http = Client::builder()
             .timeout(DEFAULT_TIMEOUT)
             .user_agent("Paracord-Federation/0.4")
+            .redirect(reqwest::redirect::Policy::limited(MAX_REDIRECTS))
             .build()
             .map_err(|e| FederationError::Http(e.to_string()))?;
 
@@ -259,6 +262,9 @@ impl FederationClient {
         &self,
         download_url: &str,
     ) -> Result<(Vec<u8>, Option<String>, Option<String>), FederationError> {
+        // SSRF protection: validate URL before making the request
+        validate_ssrf_safe_url(download_url)?;
+
         let resp = self.get_with_retry(download_url).await?;
         let content_type = resp
             .headers()
@@ -515,4 +521,213 @@ pub struct FederationFileTokenResponse {
     pub token: String,
     pub download_url: String,
     pub expires_in_seconds: i64,
+}
+
+// ---------------------------------------------------------------------------
+// SSRF protection
+// ---------------------------------------------------------------------------
+
+/// Validates that a URL is safe to request (not targeting private/internal networks).
+/// This prevents SSRF attacks where a compromised federation partner returns a
+/// download URL pointing at internal services (AWS metadata, databases, etc.).
+pub fn validate_ssrf_safe_url(url_str: &str) -> Result<(), FederationError> {
+    let parsed = url::Url::parse(url_str)
+        .map_err(|e| FederationError::Http(format!("SSRF protection: invalid download URL: {e}")))?;
+
+    // Only HTTPS is allowed — block http://, file://, ftp://, etc.
+    if parsed.scheme() != "https" {
+        return Err(FederationError::Http(format!(
+            "SSRF protection: only https:// URLs allowed, got scheme '{}'",
+            parsed.scheme()
+        )));
+    }
+
+    // Use the typed Host enum for robust IP detection (avoids IPv6 string parsing issues)
+    match parsed.host() {
+        None => {
+            return Err(FederationError::Http(
+                "SSRF protection: URL has no host".to_string(),
+            ));
+        }
+        Some(url::Host::Ipv4(v4)) => {
+            if is_private_ip(&IpAddr::V4(v4)) {
+                return Err(FederationError::Http(format!(
+                    "SSRF protection: private/reserved IP address '{v4}' is not allowed"
+                )));
+            }
+        }
+        Some(url::Host::Ipv6(v6)) => {
+            if is_private_ip(&IpAddr::V6(v6)) {
+                return Err(FederationError::Http(format!(
+                    "SSRF protection: private/reserved IP address '{v6}' is not allowed"
+                )));
+            }
+        }
+        Some(url::Host::Domain(domain)) => {
+            // Block known dangerous hostnames
+            let blocked_hosts = ["localhost", "metadata.google.internal"];
+            let lower = domain.to_ascii_lowercase();
+            for blocked in &blocked_hosts {
+                if lower == *blocked || lower.ends_with(&format!(".{}", blocked)) {
+                    return Err(FederationError::Http(format!(
+                        "SSRF protection: blocked host '{domain}'"
+                    )));
+                }
+            }
+        }
+    }
+
+    // Port whitelist: only 443 (default HTTPS) and 80
+    let port = parsed.port().unwrap_or(443);
+    if port != 443 && port != 80 {
+        return Err(FederationError::Http(format!(
+            "SSRF protection: non-standard port {port} is not allowed"
+        )));
+    }
+
+    Ok(())
+}
+
+fn is_private_ip(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            let o = v4.octets();
+            // 10.0.0.0/8
+            o[0] == 10
+            // 172.16.0.0/12
+            || (o[0] == 172 && (16..=31).contains(&o[1]))
+            // 192.168.0.0/16
+            || (o[0] == 192 && o[1] == 168)
+            // 127.0.0.0/8 (loopback)
+            || o[0] == 127
+            // 169.254.0.0/16 (link-local / AWS metadata)
+            || (o[0] == 169 && o[1] == 254)
+            // 100.64.0.0/10 (Carrier-grade NAT)
+            || (o[0] == 100 && (64..=127).contains(&o[1]))
+            // 0.0.0.0/8
+            || o[0] == 0
+            // 240.0.0.0/4 (reserved / broadcast)
+            || o[0] >= 240
+        }
+        IpAddr::V6(v6) => {
+            // ::1 loopback
+            v6.is_loopback()
+            // fc00::/7 (unique local)
+            || (v6.segments()[0] & 0xfe00) == 0xfc00
+            // fe80::/10 (link-local)
+            || (v6.segments()[0] & 0xffc0) == 0xfe80
+            // :: unspecified
+            || v6.is_unspecified()
+        }
+    }
+}
+
+#[cfg(test)]
+mod ssrf_tests {
+    use super::validate_ssrf_safe_url;
+
+    #[test]
+    fn blocks_localhost() {
+        assert!(validate_ssrf_safe_url("https://localhost/file").is_err());
+        assert!(validate_ssrf_safe_url("https://127.0.0.1/file").is_err());
+    }
+
+    #[test]
+    fn blocks_aws_metadata() {
+        assert!(validate_ssrf_safe_url("https://169.254.169.254/latest/meta-data/").is_err());
+    }
+
+    #[test]
+    fn blocks_private_ip_ranges() {
+        assert!(validate_ssrf_safe_url("https://10.0.0.1/file").is_err());
+        assert!(validate_ssrf_safe_url("https://192.168.1.1/file").is_err());
+        assert!(validate_ssrf_safe_url("https://172.16.0.1/file").is_err());
+        assert!(validate_ssrf_safe_url("https://172.31.255.255/file").is_err());
+    }
+
+    #[test]
+    fn blocks_carrier_grade_nat() {
+        assert!(validate_ssrf_safe_url("https://100.64.0.1/file").is_err());
+        assert!(validate_ssrf_safe_url("https://100.127.255.255/file").is_err());
+    }
+
+    #[test]
+    fn blocks_http_scheme() {
+        assert!(validate_ssrf_safe_url("http://example.com/file").is_err());
+    }
+
+    #[test]
+    fn blocks_file_scheme() {
+        assert!(validate_ssrf_safe_url("file:///etc/passwd").is_err());
+    }
+
+    #[test]
+    fn blocks_non_standard_ports() {
+        assert!(validate_ssrf_safe_url("https://example.com:8080/file").is_err());
+        assert!(validate_ssrf_safe_url("https://example.com:6379/file").is_err());
+    }
+
+    #[test]
+    fn blocks_google_metadata() {
+        assert!(validate_ssrf_safe_url("https://metadata.google.internal/computeMetadata/v1/").is_err());
+    }
+
+    #[test]
+    fn blocks_ipv6_loopback() {
+        assert!(validate_ssrf_safe_url("https://[::1]/file").is_err());
+    }
+
+    #[test]
+    fn blocks_ipv6_link_local() {
+        assert!(validate_ssrf_safe_url("https://[fe80::1]/file").is_err());
+    }
+
+    #[test]
+    fn blocks_ipv6_unique_local() {
+        assert!(validate_ssrf_safe_url("https://[fc00::1]/file").is_err());
+        assert!(validate_ssrf_safe_url("https://[fd00::1]/file").is_err());
+    }
+
+    #[test]
+    fn blocks_reserved_ip_range() {
+        assert!(validate_ssrf_safe_url("https://240.0.0.1/file").is_err());
+        assert!(validate_ssrf_safe_url("https://255.255.255.255/file").is_err());
+    }
+
+    #[test]
+    fn blocks_zero_ip() {
+        assert!(validate_ssrf_safe_url("https://0.0.0.0/file").is_err());
+    }
+
+    #[test]
+    fn allows_public_https() {
+        assert!(validate_ssrf_safe_url("https://cdn.example.com/files/abc123").is_ok());
+        assert!(validate_ssrf_safe_url("https://federation.partner.org/v1/file/download?token=abc").is_ok());
+    }
+
+    #[test]
+    fn allows_standard_ports() {
+        assert!(validate_ssrf_safe_url("https://cdn.example.com:443/file").is_ok());
+        assert!(validate_ssrf_safe_url("https://cdn.example.com:80/file").is_ok());
+    }
+
+    #[test]
+    fn blocks_empty_and_garbage() {
+        assert!(validate_ssrf_safe_url("").is_err());
+        assert!(validate_ssrf_safe_url("not-a-url").is_err());
+    }
+
+    #[test]
+    fn allows_public_ip() {
+        assert!(validate_ssrf_safe_url("https://8.8.8.8/file").is_ok());
+        assert!(validate_ssrf_safe_url("https://1.1.1.1/file").is_ok());
+    }
+
+    #[test]
+    fn blocks_172_outside_private_range_is_allowed() {
+        // 172.15.x.x is NOT in the 172.16-31 private range
+        assert!(validate_ssrf_safe_url("https://172.15.0.1/file").is_ok());
+        // 172.32.x.x is NOT in the 172.16-31 private range
+        assert!(validate_ssrf_safe_url("https://172.32.0.1/file").is_ok());
+    }
 }


### PR DESCRIPTION
download_federated_file() followed arbitrary URLs from remote servers without validating the target, allowing a compromised federation partner to probe internal services (AWS metadata, databases, localhost, etc.).

Add validate_ssrf_safe_url() that enforces:
- HTTPS-only scheme
- Reject private/reserved IPv4 and IPv6 ranges (RFC1918, link-local, loopback, carrier-grade NAT, reserved)
- Block known dangerous hostnames (localhost, metadata.google.internal)
- Port whitelist (443, 80 only, i am not sure if we want this but on a proper setup those only should ever be used )
- Redirect limit (max 3) on the federation HTTP client

Includes 18 unit tests covering all blocked ranges and edge cases.